### PR TITLE
Update to latest openmod

### DIFF
--- a/SilK.Unturned.Extras/SilK.Unturned.Extras.csproj
+++ b/SilK.Unturned.Extras/SilK.Unturned.Extras.csproj
@@ -33,12 +33,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
-		<PackageReference Include="OpenMod.Unturned" Version="3.2.7" />
+		<PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
+		<PackageReference Include="OpenMod.Unturned" Version="3.7.4" />
 		<PackageReference Include="Legacy2CPSWorkaround" Version="1.0.0">
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -51,5 +51,4 @@
 			</ReferencePath>
 		</ItemGroup>
 	</Target>
-
 </Project>

--- a/samples/UnturnedExtrasTest/UnturnedExtrasTest.csproj
+++ b/samples/UnturnedExtrasTest/UnturnedExtrasTest.csproj
@@ -18,11 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenMod.Unturned" Version="3.0.28" />
+    <PackageReference Include="OpenMod.Unturned" Version="3.7.4" />
     <PackageReference Include="Legacy2CPSWorkaround" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
With the latest versions of openmod. 
`FindFromAssembly<ServiceImplementationAttribute>` returns both global services and plugin services. 
Removing `FindFromAssembly<PluginServiceImplementationAttribute>` fixes listening to evens twice on plugin services